### PR TITLE
fix: correção de escopos opcionais

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -8,8 +8,11 @@ module.exports = {
     ],
     'scope-enum': [
       2,
-      'never',
+      'always',
       ['backend', 'frontend', 'api', 'ui', 'database', 'docs']
+    ],
+    'scope-empty': [
+      2, 'always',
     ],
     'subject-max-length': [2, 'always', 50],
     'body-max-line-length': [2, 'always', 72]


### PR DESCRIPTION
Correção da checagem de escopos adicionais do conventional commits.

## Como usar

```bash
# Exemplo de commits válidos
git commit -m "feat(backend): adicionar autenticação de usuário"
git commit -m "fix(frontend): corrigir bug do botão de login"
git commit -m "docs: atualizar README com instruções"