### PR TITLE
fix: correção de checagem de escopo opcional v2

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,19 +1,14 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'type-enum': [
-      2,
-      'always',
+    'type-enum': [2, 'always',
       ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'chore']
     ],
-    'scope-enum': [
-      2,
-      'always',
+
+    'scope-enum': [2, 'always',
       ['backend', 'frontend', 'api', 'ui', 'database', 'docs']
     ],
-    'scope-empty': [
-      2, 'always',
-    ],
+
     'subject-max-length': [2, 'always', 50],
     'body-max-line-length': [2, 'always', 72]
   }


### PR DESCRIPTION
Adicionada mais uma correção da checagem de escopo opcional.

## Como usar
```bash
# Exemplo de commits válidos
git commit -m "feat(backend): adicionar autenticação de usuário"
git commit -m "fix(frontend): corrigir bug do botão de login"
git commit -m "docs: atualizar README com instruções"