### PR TITLE
fix: aumentar limite do subject para 75 caracteres

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -9,7 +9,7 @@ module.exports = {
       ['backend', 'frontend', 'api', 'ui', 'database', 'docs']
     ],
 
-    'subject-max-length': [2, 'always', 50],
+    'subject-max-length': [2, 'always', 75],
     'body-max-line-length': [2, 'always', 72]
   }
 };


### PR DESCRIPTION
Aumenta o limite de caracteres do subject de commits de 50 para 75 caracteres.

## Mudança

- `subject-max-length`: 50 → 75 caracteres